### PR TITLE
Chore/update io provider

### DIFF
--- a/app/player/platform/io-provider.js
+++ b/app/player/platform/io-provider.js
@@ -52,7 +52,7 @@ function IOProvider(serviceUrls) {
 
         return Promise.resolve(filteredItems.map(function(f) {
           return  {
-            remoteUrl: f.selfLink + "?alt=media",
+            remoteUrl: f.mediaLink,
             filePath: f.objectId.substr(folder.length)
           };
         }));


### PR DESCRIPTION
@fjvallarino Chrome filesystem save was not clearing out old data on the file.  It overwrites the beginning bytes and leaves the rest of the file intact.   So if you save *test.txt*="abcdef" and then save *test.txt*="123" then what you end up with is *test.txt*="123def".  

I spent quite a bit of time yesterday trying to figure out what was going on with the file save because of that.