### PR TITLE
Update storage-component integration

### DIFF
--- a/app/player/platform/content-event-handlers/storage-component-load.js
+++ b/app/player/platform/content-event-handlers/storage-component-load.js
@@ -47,12 +47,12 @@ module.exports = function(platformIO, uiController) {
       }
 
       function sendResponseToListeners(data) {
-        uiController.sendWindowMessage(evt.source, { type: "storage-component-loaded", response: data }, "*");
+        uiController.sendWindowMessage(evt.source, { type: "storage-component-loaded", clientId: evt.data.clientId, response: data }, "*");
       }
 
       function sendErrorToListeners(err) {
         console.log("sendErrorToListeners", err);
-        uiController.sendWindowMessage(evt.source, { type: "storage-component-loaded", error: "Failed to fetch data" }, "*");
+        uiController.sendWindowMessage(evt.source, { type: "storage-component-loaded", clientId: evt.data.clientId, error: "Failed to fetch data" }, "*");
       }
 
       function respondWithError(err) {

--- a/app/player/platform/content-event-handlers/storage-component-response.js
+++ b/app/player/platform/content-event-handlers/storage-component-response.js
@@ -56,7 +56,7 @@ module.exports = function(serviceUrls, platformIO, remoteFolderFetcher, uiContro
       }
 
       function sendProcessedResponse(resp, items) {
-        var message = {type: "storage-component-response-updated", response: resp};
+        var message = {type: "storage-component-response-updated", clientId: evt.data.clientId, response: resp};
 
         items.forEach(function(item) {
           item.selfLink = platformIO.isNetworkConnected() ? item.remoteUrl : item.filePath;

--- a/app/player/platform/content-event-handlers/storage-component-response.js
+++ b/app/player/platform/content-event-handlers/storage-component-response.js
@@ -12,7 +12,7 @@ module.exports = function(serviceUrls, platformIO, remoteFolderFetcher, uiContro
       }
 
       // Process a single file or a list of files. 
-      var items = resp.selfLink ? [resp] : resp.items;
+      var items = resp.selfLink ? [resp] : resp.files;
 
       return generateLocalAndRemoteUrls(items)
       .then(fetchFilesIntoFilesystem)
@@ -52,7 +52,7 @@ module.exports = function(serviceUrls, platformIO, remoteFolderFetcher, uiContro
         var parentFolder = decodeURIComponent(items[0].selfLink.replace("/o", ""));
 
         parentFolder = parentFolder.substr(0, parentFolder.lastIndexOf("/") + 1);
-        return platformIO.registerTargets(serviceUrls.registerTargetUrl, [parentFolder], false);
+        return platformIO.registerTargets(serviceUrls.registerTargetUrl, [{ objectReference: parentFolder }], false);
       }
 
       function sendProcessedResponse(resp, items) {

--- a/test/platform/content-event-handlers/storage-component-response-test.js
+++ b/test/platform/content-event-handlers/storage-component-response-test.js
@@ -35,7 +35,7 @@ describe("storage-component-response", function() {
       data: {
         type: "storage-component-response",
         response: {
-          items: [item]
+          files: [item]
        }
       }
     };
@@ -106,7 +106,7 @@ describe("storage-component-response", function() {
   it("registers GCM targets", function(done) {
     responseHandler.process(eventObject, presentationUrl).then(function() {
       assert.equal(mockPlatformIO.registerTargets.callCount, 1);
-      assert.equal(mockPlatformIO.registerTargets.lastCall.args[1], mainUrlPath);
+      assert.equal(mockPlatformIO.registerTargets.lastCall.args[1][0].objectReference, mainUrlPath);
       done();
     });
   });
@@ -116,7 +116,7 @@ describe("storage-component-response", function() {
       var arg1 = mockUIController.sendWindowMessage.lastCall.args[1];
 
       assert.equal(mockUIController.sendWindowMessage.callCount, 1);
-      assert.equal(arg1.response.items[0].selfLink, imageSelfLink + "?alt=media");
+      assert.equal(arg1.response.files[0].selfLink, imageSelfLink + "?alt=media");
       done();
     });
   });


### PR DESCRIPTION
This PR uses the *files* attribute provided by Storage API (Google used *items*) and includes the clientId provided by the client (which should be used to only process responses sent to that particular client)

@tejohnso please review
