### PR TITLE
Handle token expiration and renewal

### DIFF
--- a/app/player/channel/token-retriever.js
+++ b/app/player/channel/token-retriever.js
@@ -61,7 +61,7 @@ module.exports = function(platformIO, serviceUrls) {
     }
     else {
       logger.external("invalid channel token null");
-      return Promise.reject("Invalid channel token - Null");
+      return Promise.reject("Invalid channel token - " + data.status.message);
     }
   }
 };

--- a/app/player/main/channel-supervisor.js
+++ b/app/player/main/channel-supervisor.js
@@ -1,18 +1,7 @@
-module.exports = function(ioProvider, tokenRetriever, channelManager, onlineStatusObserver) {
-  var token;
-
-  function updateToken() {
-    return tokenRetriever.getToken().then(function(newToken) {
-      token = newToken;
-      return token;
-    });
-  }
-
+module.exports = function(ioProvider, channelManager, onlineStatusObserver) {
   function handleNetworkStatusChange(status) {
     if(status) {
-      var promise = token ? Promise.resolve(token) : updateToken();
-
-      return promise.then(channelManager.createChannel);
+      return channelManager.createChannel();
     }
     else if(token) {
       return channelManager.destroyChannel();

--- a/app/player/main/start.js
+++ b/app/player/main/start.js
@@ -35,10 +35,10 @@ module.exports = function(serviceUrls, externalLogger, platformInfo) {
 
   messageDetailRetriever = require("../channel/message-detail-retriever.js")(platformIOProvider, serviceUrls),
 
-  channelManager = require("../channel/channel-manager.js")(messageDetailRetriever, platformUIController),
+  channelManager = require("../channel/channel-manager.js")(tokenRetriever, messageDetailRetriever, platformUIController),
 
   channelSupervisor = require("../main/channel-supervisor.js")
-  (platformIOProvider, tokenRetriever, channelManager, onlineStatusObserver);
+  (platformIOProvider, channelManager, onlineStatusObserver);
   
   global.logger = require("../logging/logger.js")(externalLogger);
 

--- a/test/channel/channel-manager-test.js
+++ b/test/channel/channel-manager-test.js
@@ -5,6 +5,7 @@ rebootHandlerPath = "../../app/player/channel/handlers/reboot-handler.js",
 restartHandlerPath = "../../app/player/channel/handlers/restart-handler.js",
 mock = require("simple-mock").mock,
 mockPlatformProvider,
+mockTokenRetriever,
 mockMessageRetriever,
 mockUIController,
 eventData,
@@ -15,10 +16,14 @@ manager;
 describe("channel manager", function() {
   beforeEach("setup mocks", function() {
     global.logger = {};
+    global.document = { body: {}, view: {} };
+    global.window = {};
+
     mock(global.logger, "console").returnWith(true);
     mock(global.logger, "external").returnWith(true);
 
     mockPlatformProvider = {};
+    mockTokenRetriever = {};
     mockMessageRetriever = {};
     mockUIController = {};
     eventData = {
@@ -30,16 +35,56 @@ describe("channel manager", function() {
     rebootHandler = require(rebootHandlerPath)(mockPlatformProvider);
     restartHandler = require(restartHandlerPath)(mockPlatformProvider);
 
+    mock(mockTokenRetriever, "getToken").resolveWith("test-token");
     mock(mockMessageRetriever, "getMessageDetail").resolveWith(eventData);
     mock(mockUIController, "sendWindowMessage").resolveWith(true);
     mock(rebootHandler, "process").resolveWith(true);
     mock(restartHandler, "process").resolveWith(true);
 
-    manager = require(managerPath)(mockMessageRetriever, mockUIController);
+    mock(document, "createElement").returnWith({
+      contentWindow: {},
+      style: {},
+      addEventListener: function() {},
+      removeEventListener: function() {}
+    });
+
+    mock(document.body, "appendChild").returnWith(true);
+    mock(document.body, "removeChild").returnWith(true);
+    mock(window, "addEventListener").returnWith(true);
+
+    manager = require(managerPath)(mockTokenRetriever, mockMessageRetriever, mockUIController);
   });
 
   it("exists", function() {
     assert.ok(manager);
+  });
+
+  it("requests a token and creates the channel webview", function() {
+    return manager.createChannel().then(function() {
+      assert(mockTokenRetriever.getToken.called);
+      assert(document.createElement.called);
+      assert(document.body.appendChild.called);
+      assert(window.addEventListener.called);
+      assert(global.logger.external.called);
+    });
+  });
+
+  it("only gets a new token if it does not have one", function() {
+    return manager.createChannel()
+    .then(manager.createChannel)
+    .then(function() {
+      assert.equal(mockTokenRetriever.getToken.callCount, 1);
+    });
+  });
+
+  it("closes the channel and destroys the channel webview", function() {
+    return manager.createChannel()
+    .then(manager.destroyChannel)
+    .then(function() {
+      assert(document.body.removeChild.called);
+      assert(mockUIController.sendWindowMessage.called);
+      assert(global.logger.external.called);
+    });
   });
 
   it("invokes the correct handler", function() {
@@ -98,12 +143,23 @@ describe("channel manager", function() {
   });
 
   it("handles channel errors", function() {
-    var message = { type: "channel-error", code: 101, description: "failed"};
+    var message = { type: "channel-error", code: "101", description: "failed"};
     var evt = { data: message };
 
     return manager.processMessage(evt).then(function() {
       assert(global.logger.external.called);
       assert.equal(global.logger.external.callCount, 1);
+      assert(!mockTokenRetriever.getToken.called);
+    });
+  });
+
+  it("requests a new token and re creates the channel", function() {
+    var message = { type: "channel-error", code: "401", description: "" };
+    var evt = { data: message };
+
+    return manager.processMessage(evt).then(function() {
+      assert(mockTokenRetriever.getToken.called);
+      assert(global.logger.external.called);
     });
   });
 });

--- a/test/channel/token-retriever-test.js
+++ b/test/channel/token-retriever-test.js
@@ -96,14 +96,14 @@ describe("token-retriever", function() {
   it("rejects because a valid token could not be retrieved", function() {
     mock(mockPlatformIO, "httpFetcher").resolveWith({
       json: function() {
-        return Promise.resolve({});
+        return Promise.resolve({ status: { message: "Multiple clients are using the same display id" } });
       }
     });
 
     return retriever.getToken()
     .then(null, function(err) {
       assert(err);
-      assert.equal(err, "Invalid channel token - Null");
+      assert.equal(err, "Invalid channel token - Multiple clients are using the same display id");
 
       assert(global.logger.external.called);
       assert.equal(global.logger.external.callCount, 1);

--- a/test/main/channel-supervisor-test.js
+++ b/test/main/channel-supervisor-test.js
@@ -4,24 +4,21 @@ supervisorPath = "../../app/player/main/channel-supervisor.js",
 supervisor,
 mock = require("simple-mock").mock,
 mockPlatformIO,
-mockTokenRetriever,
 mockChannelManager,
 mockOnlineStatusObserver;
 
 describe("channel supervisor", function() {
   beforeEach("setup mocks", function() {
     mockPlatformIO = {};
-    mockTokenRetriever = {};
     mockChannelManager = {};
     mockOnlineStatusObserver = {};
 
     mock(mockPlatformIO, "isNetworkConnected").returnWith(true);
-    mock(mockTokenRetriever, "getToken").resolveWith("test-token");
     mock(mockChannelManager, "createChannel").resolveWith(true);
     mock(mockChannelManager, "destroyChannel").resolveWith(true);
     mock(mockOnlineStatusObserver, "addEventHandler").resolveWith(true);
 
-    supervisor = require(supervisorPath)(mockPlatformIO, mockTokenRetriever, mockChannelManager, mockOnlineStatusObserver);
+    supervisor = require(supervisorPath)(mockPlatformIO, mockChannelManager, mockOnlineStatusObserver);
   });
 
   it("exists", function() {
@@ -30,7 +27,6 @@ describe("channel supervisor", function() {
 
   it("properly starts supervisor creating channel and observing online status changes", function() {
     return supervisor.start().then(function() {
-      assert(mockTokenRetriever.getToken.called);
       assert(mockChannelManager.createChannel.called);
       assert(!mockChannelManager.destroyChannel.called);
       assert(mockOnlineStatusObserver.addEventHandler.called);
@@ -41,7 +37,6 @@ describe("channel supervisor", function() {
     mock(mockPlatformIO, "isNetworkConnected").returnWith(false);
 
     return supervisor.start().then(function() {
-      assert(!mockTokenRetriever.getToken.called);
       assert(!mockChannelManager.createChannel.called);
       assert(!mockChannelManager.destroyChannel.called);
       assert(mockOnlineStatusObserver.addEventHandler.called);
@@ -56,12 +51,10 @@ describe("channel supervisor", function() {
     };
 
     return supervisor.start().then(function() {
-      assert.equal(mockTokenRetriever.getToken.callCount, 1);
       assert.equal(mockChannelManager.createChannel.callCount, 1);
       assert.equal(mockChannelManager.destroyChannel.callCount, 0);
       
       return statusChangeHandler(false).then(function() {
-        assert.equal(mockTokenRetriever.getToken.callCount, 1);
         assert.equal(mockChannelManager.createChannel.callCount, 1);
         assert.equal(mockChannelManager.destroyChannel.callCount, 1);
       });


### PR DESCRIPTION
Refactor channel supervisor to move token request to channel manager. This way it can be used to renew the token when it expires.

@tejohnso please review